### PR TITLE
Remove provider, make spf and dkim optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ resource "cloudflare_record" "mx" {
 }
 
 resource "cloudflare_record" "spf" {
+  count   = var.spf_enable ? 1 : 0
   zone_id = var.cf_zone_id
   name    = var.sub_domain
   type    = "TXT"
@@ -32,7 +33,7 @@ resource "cloudflare_record" "spf" {
 
 
 resource "cloudflare_record" "dkim" {
-  for_each = { for i in range(1, 4) : "${i}" => i }
+  for_each = { for i in(var.dkim_enable ? range(1, 4) : []) : "${i}" => i }
   zone_id  = var.cf_zone_id
   type     = "CNAME"
   name     = "fm${each.value}._domainkey"

--- a/main.tf
+++ b/main.tf
@@ -7,10 +7,6 @@ terraform {
   }
 }
 
-provider "cloudflare" {
-  api_token = var.cf_api_token
-}
-
 resource "cloudflare_record" "mx" {
   for_each = {
     primary   = { server = "in1-smtp.messagingengine.com", priority = 10 }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 3.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "cloudflare_record" "spf" {
   zone_id = var.cf_zone_id
   name    = var.sub_domain
   type    = "TXT"
-  value   = "v=spf1 include:spf.messagingengine.com ?all "
+  value   = "v=spf1 include:spf.messagingengine.com ?all"
   ttl     = var.ttl
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -29,3 +29,15 @@ variable "dmarc" {
   description = "DMARC specification (optional)"
   type        = string
 }
+
+variable "dkim_enable" {
+  default     = true
+  description = "Add dkim records"
+  type        = bool
+}
+
+variable "spf_enable" {
+  default     = true
+  description = "Add spf records"
+  type        = bool
+}


### PR DESCRIPTION
- I removed the provider section because the latest terraform is throwing errors for modules which have their own provider section
- I made the spf/dkim records optional (defaulting to adding them). I had a requirement where I wanted to use this module for fastmail's incredibly useful wildcard domain feature(sending mail to abc@xyz.domain goes to xyz+abc@domain), but I just wanted mx records and not spf/dkim. So I could do:
```hcl

module "fastmail-mx" {
  source = "github.com/sandipb/terraform-cloudflare-fastmail-mx.git?ref=remove_provider"
  for_each = {
    root     = { sub_domain = "@", dkim_enable = true, spf_enable = true },
    wildcard = { sub_domain = "*", dkim_enable = false, spf_enable = false }
  }
  cf_zone_id   = data.cloudflare_zone.sandipb_dev.id
  cf_api_token = var.cf_api_token
  domain_name  = data.cloudflare_zone.sandipb_dev.name
  sub_domain   = each.value.sub_domain
  dkim_enable   = each.value.dkim_enable
  spf_enable   = each.value.spf_enable
}
```